### PR TITLE
Fix learning disaibility and carehome labels

### DIFF
--- a/analysis/config.py
+++ b/analysis/config.py
@@ -13,13 +13,13 @@ demographics = [
     "sex",
     "region",
     "carehome",
-    "ld",
+    "learning_disability",
     "imd",
     "ethnicity",
 ]
 
 # subgroups for LDA population plots
-lda_measures = ["carehome", "ld", "autism"]
+lda_measures = ["carehome", "learning_disability", "autism"]
 
 # name of measure
 marker = "Depression review"

--- a/analysis/demographic_variables.py
+++ b/analysis/demographic_variables.py
@@ -112,19 +112,18 @@ demographic_variables = dict(
         },
     ),
     # Learning disability
-    # TODO: can there be missing binary flag? Or set to no?
-    ld=patients.with_these_clinical_events(
-        learning_disability_codes,
-        on_or_before="last_day_of_month(index_date)",
-        returning="binary_flag",
-        return_expectations={"incidence": 0.2},
-    ),
-    ld_label=patients.categorised_as(
+    learning_disability=patients.categorised_as(
         {
             "Unknown": "DEFAULT",
             "No record of learning disability": "ld='0'",
             "Record of learning disability": "ld='1'",
         },
+        ld=patients.with_these_clinical_events(
+            learning_disability_codes,
+            on_or_before="last_day_of_month(index_date)",
+            returning="binary_flag",
+            return_expectations={"incidence": 0.2},
+        ),
         return_expectations={
             "rate": "universal",
             "category": {
@@ -137,18 +136,18 @@ demographic_variables = dict(
         },
     ),
     # Autism
-    autism=patients.with_these_clinical_events(
-        autism_codes,
-        on_or_before="index_date",
-        returning="binary_flag",
-        return_expectations={"incidence": 0.3},
-    ),
-    autism_label=patients.categorised_as(
+    autism=patients.categorised_as(
         {
             "Unknown": "DEFAULT",
-            "No record of autism": "autism='0'",
-            "Record of autism": "autism='1'",
+            "No record of autism": "aut='0'",
+            "Record of autism": "aut='1'",
         },
+        aut=patients.with_these_clinical_events(
+            autism_codes,
+            on_or_before="index_date",
+            returning="binary_flag",
+            return_expectations={"incidence": 0.3},
+        ),
         return_expectations={
             "rate": "universal",
             "category": {
@@ -161,18 +160,18 @@ demographic_variables = dict(
         },
     ),
     # Care home
-    carehome=patients.with_these_clinical_events(
-        carehome_codes,
-        on_or_before="last_day_of_month(index_date)",
-        returning="binary_flag",
-        return_expectations={"incidence": 0.2},
-    ),
-    carehome_label=patients.categorised_as(
+    carehome=patients.categorised_as(
         {
             "Unknown": "DEFAULT",
-            "Not in carehome": "carehome='0'",
-            "Carehome": "carehome='1'",
+            "Not in carehome": "ch='0'",
+            "Carehome": "ch='1'",
         },
+        ch=patients.with_these_clinical_events(
+            carehome_codes,
+            on_or_before="last_day_of_month(index_date)",
+            returning="binary_flag",
+            return_expectations={"incidence": 0.2},
+        ),
         return_expectations={
             "rate": "universal",
             "category": {

--- a/analysis/study_definition.py
+++ b/analysis/study_definition.py
@@ -334,16 +334,16 @@ for o in outcomes:
         m = Measure(
             id="{}_{}_rate".format(o, group),
             numerator=o,
-            denominator=group,
-            group_by=["population"],
+            denominator="population",
+            group_by=[group],
             small_number_suppression=True,
         )
         measures.append(m)
         new_m = Measure(
             id="new_{}_{}_rate".format(o, group),
             numerator="new_{}".format(o),
-            denominator=group,
-            group_by=["population"],
+            denominator="population",
+            group_by=[group],
             small_number_suppression=True,
         )
         measures.append(new_m)


### PR DESCRIPTION
The measures framework requires that the denominator is a number and not
a string. Rather than do numerator/carehome with groupby=population, do
numerator/population with groupby=carehome. This means the measures file
will have a row for each group rather than just the subgroup, but we can
sort that later in plotting.