### PR TITLE
Build denominator rule by rule

### DIFF
--- a/analysis/study_definition_dep003.py
+++ b/analysis/study_definition_dep003.py
@@ -92,6 +92,17 @@ for d in demographics:
     )
     measures.append(m)
 
+### Debugging
+for i in range(1, 9):
+    m = Measure(
+        id=f"dep003_denominator_r{i}_total_rate",
+        numerator=f"dep003_denominator_r{i}",
+        denominator="population",
+        group_by="population",
+        small_number_suppression=True,
+    )
+    measures.append(m)
+
 ### Exclusions
 exclusions = ["unsuitable_12mo", "dissent_12mo"]
 for ex in exclusions:


### PR DESCRIPTION
Instead of having separate rules for each denominator that we compose in
one variable, add the previous rule's dependencies to the current rule.

Expose each denominator rule as a measure so we can debug