### PR TITLE
Extract ethnicity 16 groups

### DIFF
--- a/analysis/codelists.py
+++ b/analysis/codelists.py
@@ -121,9 +121,9 @@ anxiety_codes = codelist_from_csv(
 # Variables
 
 # Ethnicity
-ethnicity_codes_6 = codelist_from_csv(
+ethnicity_codes_16 = codelist_from_csv(
     "codelists/opensafely-ethnicity-snomed-0removed.csv",
     system="snomed",
     column="snomedcode",
-    category_column="Grouping_6",
+    category_column="Grouping_16",
 )

--- a/analysis/config.py
+++ b/analysis/config.py
@@ -18,6 +18,7 @@ demographics = [
     "learning_disability",
     "imd",
     "ethnicity",
+    "ethnicity16",
 ]
 
 # Subgroups for LDA population plots

--- a/analysis/study_definition_ethnicity.py
+++ b/analysis/study_definition_ethnicity.py
@@ -5,7 +5,7 @@ from cohortextractor import (
 
 from config import start_date
 
-from codelists import ethnicity_codes_6
+from codelists import ethnicity_codes_16
 
 study = StudyDefinition(
     default_expectations={
@@ -19,33 +19,44 @@ study = StudyDefinition(
     population=patients.all(),
     # Categories from 2001 census
     # https://www.ethnicity-facts-figures.service.gov.uk/style-guide/ethnic-groups#2001-census
+    eth16=patients.with_these_clinical_events(
+        ethnicity_codes_16,
+        returning="category",
+        find_last_match_in_period=True,
+        include_date_of_match=False,
+        return_expectations={
+            "category": {
+                "ratios": {
+                    "1": 0.1,
+                    "2": 0.1,
+                    "3": 0.1,
+                    "4": 0.1,
+                    "5": 0.05,
+                    "6": 0.05,
+                    "7": 0.05,
+                    "8": 0.05,
+                    "9": 0.05,
+                    "10": 0.05,
+                    "11": 0.05,
+                    "12": 0.05,
+                    "13": 0.05,
+                    "14": 0.05,
+                    "15": 0.05,
+                    "16": 0.05,
+                }
+            },
+            "incidence": 0.75,
+        },
+    ),
     ethnicity=patients.categorised_as(
         {
             "Unknown": "DEFAULT",
-            "White": "eth='1'",
-            "Mixed": "eth='2'",
-            "Asian or Asian British": "eth='3'",
-            "Black or Black British": "eth='4'",
-            "Chinese or Other": "eth='5'",
+            "White": "eth16='1' OR eth16='2' OR eth16='3'",
+            "Mixed": "eth16='4' OR eth16='5' OR eth16='6' OR eth16='7'",
+            "Asian or Asian British": "eth16='8' OR eth16='9' OR eth16='10' OR eth16='11'",
+            "Black or Black British": "eth16='12' OR eth16='13' OR eth16='14'",
+            "Chinese or Other": "eth16='15' OR eth16='16'",
         },
-        eth=patients.with_these_clinical_events(
-            ethnicity_codes_6,
-            returning="category",
-            find_last_match_in_period=True,
-            include_date_of_match=False,
-            return_expectations={
-                "category": {
-                    "ratios": {
-                        "1": 0.2,
-                        "2": 0.2,
-                        "3": 0.2,
-                        "4": 0.2,
-                        "5": 0.1,
-                    }
-                },
-                "incidence": 0.75,
-            },
-        ),
         return_expectations={
             "rate": "universal",
             "category": {
@@ -56,6 +67,51 @@ study = StudyDefinition(
                     "Black or Black British": 0.2,
                     "Chinese or Other": 0.1,
                     "Unknown": 0.2,
+                }
+            },
+        },
+    ),
+    ethnicity16=patients.categorised_as(
+        {
+            "Unknown": "DEFAULT",
+            "White-British": "eth16='1'",
+            "White-Irish": "eth16='2'",
+            "White-Any other White background": "eth16='3'",
+            "Mixed-White and Black Caribbean": "eth16='4'",
+            "Mixed-White and Black African": "eth16='5'",
+            "Mixed-White and Asian": "eth16='6'",
+            "Mixed-Any other mixed background": "eth16='7'",
+            "Asian or Asian British-Indian": "eth16='8'",
+            "Asian or Asian British-Pakistani": "eth16='9'",
+            "Asian or Asian British-Bangladeshi": "eth16='10'",
+            "Asian or Asian British-Any other Asian background": "eth16='11'",
+            "Black or Black British-Caribbean": "eth16='12'",
+            "Black or Black British-African": "eth16='13'",
+            "Black or Black British-Any other Black background": "eth16='14'",
+            "Other Ethnic Groups-Chinese": "eth16='15'",
+            "Other Ethnic Groups-Any other ethnic group": "eth16='16'",
+        },
+        return_expectations={
+            "rate": "universal",
+            "category": {
+                "ratios": {
+                    "Unknown": 0.1,
+                    "White-British": 0.1,
+                    "White-Irish": 0.05,
+                    "White-Any other White background": 0.1,
+                    "Mixed-White and Black Caribbean": 0.05,
+                    "Mixed-White and Black African": 0.05,
+                    "Mixed-White and Asian": 0.05,
+                    "Mixed-Any other mixed background": 0.05,
+                    "Asian or Asian British-Indian": 0.05,
+                    "Asian or Asian British-Pakistani": 0.05,
+                    "Asian or Asian British-Bangladeshi": 0.05,
+                    "Asian or Asian British-Any other Asian background": 0.05,
+                    "Black or Black British-Caribbean": 0.05,
+                    "Black or Black British-African": 0.05,
+                    "Black or Black British-Any other Black background": 0.05,
+                    "Other Ethnic Groups-Chinese": 0.05,
+                    "Other Ethnic Groups-Any other ethnic group": 0.05,
                 }
             },
         },


### PR DESCRIPTION
Extract the 16 codes so we can include the more detailed breakdown in the table 1.

Manually group the 16 codes to match the 6 labels so we do not have to extract two code for each person.